### PR TITLE
feat!: rename to @mrgrain/jsii-struct-builder

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -3,14 +3,13 @@ const project = new typescript.TypeScriptProject({
   projenrcTs: true,
 
   // Project info
-  name: '@mrgrain/jsii-extend-interface',
-  description:
-    'A projen component to easily extend and adapt existing jsii interfaces',
+  name: '@mrgrain/jsii-struct-builder',
+  description: 'Build jsii structs with ease',
   authorName: 'Momo Kornher',
   authorEmail: 'mail@moritzkornher.de',
   authorUrl: 'https://moritzkornher.de',
-  repository: 'https://github.com/mrgrain/jsii-extend-interface',
-  homepage: 'https://github.com/mrgrain/jsii-extend-interface',
+  repository: 'https://github.com/mrgrain/jsii-struct-builder',
+  homepage: 'https://github.com/mrgrain/jsii-struct-builder',
   sampleCode: false,
 
   // TypeScript

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# jsii-extend-interface
+# jsii-struct-builder
 
-A projen component to easily extend and adapt existing jsii interfaces.
+Build jsii structs with ease.
 
-Jsii doesn't support TypeScript [Utility Types](https://www.typescriptlang.org/docs/handbook/utility-types.html) like `Partial` or `Omit`, making it difficult to extend existing interfaces.
-This component works around that limitation by generating a brand new interface based on the jsii specification of the extended interface and its parent interfaces.
+Jsii doesn't support TypeScript [Utility Types](https://www.typescriptlang.org/docs/handbook/utility-types.html) like `Partial` or `Omit`, making it difficult to re-use existing [struct interfaces](https://aws.github.io/jsii/specification/2-type-system/#structs).
+With this package, you can work around that limitation and create brand new struct interfaces based on the jsii specification of any existing structs, their parents, and your custom specification.
 
-From jsii's perspective, these interfaces are completely new types. From a maintainer's perspective, they require the same minimal effort
-as utility types do. Everybody wins!
+From jsii's perspective, these structs are completely new types.
+From a maintainer's perspective, they require the same minimal effort as utility types do.
+Everybody wins!
 
 ## Usage
 
 Install with:
 
 ```console
-npm install --save-dev @mrgrain/jsii-extend-interface
+npm install --save-dev @mrgrain/jsii-struct-builder
 ```
 
 ### Extending an Interface

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@mrgrain/jsii-extend-interface",
-  "description": "A projen component to easily extend and adapt existing jsii interfaces",
+  "name": "@mrgrain/jsii-struct-builder",
+  "description": "Build jsii structs with ease",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mrgrain/jsii-extend-interface"
+    "url": "https://github.com/mrgrain/jsii-struct-builder"
   },
   "scripts": {
     "build": "npx projen build",
@@ -60,7 +60,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/mrgrain/jsii-extend-interface",
+  "homepage": "https://github.com/mrgrain/jsii-struct-builder",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
BREAKING CHANGE: Rename package to @mrgrain/jsii-struct-builder. The old name did not correctly reflect what this package does. The new name will allow to develop this package into a more useful direction.