### PR TITLE
chore: use polyfill so structuredClone can be used with node16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.0.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
         run: |-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -54,7 +50,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 16.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -79,7 +75,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 16.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -18,10 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,7 +6,11 @@
     },
     {
       "name": "@types/node",
-      "version": "^18",
+      "version": "^16",
+      "type": "build"
+    },
+    {
+      "name": "@types/ungap__structured-clone",
       "type": "build"
     },
     {
@@ -89,6 +93,10 @@
     },
     {
       "name": "@jsii/spec",
+      "type": "runtime"
+    },
+    {
+      "name": "@ungap/structured-clone",
       "type": "runtime"
     }
   ],

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -183,7 +183,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --coverageProvider=v8 --updateSnapshot",
+          "exec": "jest --passWithNoTests --updateSnapshot",
           "receiveArgs": true
         },
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,7 +13,6 @@ const project = new typescript.TypeScriptProject({
   sampleCode: false,
 
   // Node & TypeScript config
-  minNodeVersion: '18.0.0',
   tsconfig: {
     compilerOptions: {
       lib: ['es2022'],
@@ -55,8 +54,8 @@ const project = new typescript.TypeScriptProject({
   }),
 
   // Dependencies
-  deps: ['@jsii/spec'],
-  devDeps: ['projen'],
+  deps: ['@jsii/spec', '@ungap/structured-clone'],
+  devDeps: ['projen', '@types/ungap__structured-clone'],
   peerDeps: ['projen'],
   peerDependencyOptions: {
     pinnedDevDependency: false,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18",
+    "@types/node": "^16",
+    "@types/ungap__structured-clone": "^0.3.0",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
@@ -56,10 +57,8 @@
     "projen": "x.x.x"
   },
   "dependencies": {
-    "@jsii/spec": "^1.79.0"
-  },
-  "engines": {
-    "node": ">= 18.0.0"
+    "@jsii/spec": "^1.79.0",
+    "@ungap/structured-clone": "^1.0.2"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/jsii-struct-builder.ts
+++ b/src/jsii-struct-builder.ts
@@ -1,4 +1,5 @@
 import { InterfaceType, Property } from '@jsii/spec';
+import structuredClone from '@ungap/structured-clone';
 
 /**
  * Build a jsii struct

--- a/src/private/assembly.ts
+++ b/src/private/assembly.ts
@@ -7,6 +7,7 @@ import {
   Property,
   TypeKind,
 } from '@jsii/spec';
+import structuredClone from '@ungap/structured-clone';
 
 const assemblies: Record<string, Assembly> = {};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,10 +951,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.8.tgz#222383320e71f9a1397d25c416e9c62d347758e0"
   integrity sha512-kzGNJZ57XEH7RdckxZ7wfRjB9hgZABF+NLgR1B2zogUvV0gmK0/60VYA4yb4oKZckPiiJlmmfpdqTfCN0VRX+Q==
 
-"@types/node@^18":
-  version "18.15.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.9.tgz#a9b529d2a16ae73122b3875969e7db18c9f3e790"
-  integrity sha512-dUxhiNzBLr6IqlZXz6e/rN2YQXlFgOei/Dxy+e3cyXTJ4txSUbGT2/fmnD6zd/75jDMeW5bDee+YXxlFKHoV0A==
+"@types/node@^16":
+  version "16.18.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.20.tgz#8d69761aca4cf40a54dcd5c70ed313f393f8d6b5"
+  integrity sha512-9fH66vSJnF563exTu3y1g2IbDz1vCj01Lbqms97r8j0qzfFisT2biypSfybVv/eYrtTB74x9xQTdRU8RyMiRrg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -975,6 +975,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/ungap__structured-clone@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.0.tgz#39ef89de1f04bb1920ed99e549b885331295c47d"
+  integrity sha512-eBWREUhVUGPze+bUW22AgUr05k8u+vETzuYdLYSvWqGTUe0KOf+zVnOB1qER5wMcw8V6D9Ar4DfJmVvD1yu0kQ==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -1071,6 +1076,11 @@
   dependencies:
     "@typescript-eslint/types" "5.56.0"
     eslint-visitor-keys "^3.3.0"
+
+"@ungap/structured-clone@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.0.2.tgz#112bd30f3c27cb4c7b85d59ee3918c13803238ad"
+  integrity sha512-06PHwE0K24Wi8FBmC8MuMi/+nQ3DTpcXYL3y/IaZz2ScY2GOJXOe8fyMykVXyLOKxpL2Y0frAnJZmm65OxzMLQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
Lowers the minimal Node version to node16.