### PR TITLE
feat!: renderer can render struct directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ new ProjenStruct(project, { name: 'MyProjectOptions'})
   .withoutDeprecated();
 ```
 
+### Use without projen
+
+It is not required to use _projen_ with this package.
+You can use a renderer directly to create files:
+
+```ts
+const myProps = Struct.empty("@my-scope/my-pkg.MyFunctionProps")
+  .mixin(Struct.fromFqn("aws-cdk-lib.aws_lambda.FunctionProps"))
+  .withoutDeprecated();
+
+const renderer = new TypeScriptRenderer();
+fs.writeFileSync("my-props.ts", renderer.renderStruct(myProps));
+```
+
 ### Advanced usage
 
 `Struct` and `ProjenStruct` both share the same interface.

--- a/src/builder/struct.ts
+++ b/src/builder/struct.ts
@@ -9,7 +9,7 @@ export interface HasProperties {
   /**
    * The list of properties of the thing.
    */
-  properties?: Property[];
+  readonly properties?: Property[];
 }
 
 /**
@@ -19,7 +19,17 @@ export interface HasFullyQualifiedName {
   /**
    * The fully-qualified-name of the thing.
    */
-  fqn: string;
+  readonly fqn: string;
+}
+
+/**
+ * Something that has a fully-qualified-name.
+ */
+export interface HasStructSpec {
+  /**
+   * Get the current spec of the builder.
+   */
+  readonly spec: InterfaceType;
 }
 
 export interface IStructBuilder {
@@ -81,7 +91,11 @@ export interface IStructBuilder {
  * Build a jsii struct
  */
 export class Struct
-  implements IStructBuilder, HasProperties, HasFullyQualifiedName
+  implements
+    IStructBuilder,
+    HasProperties,
+    HasFullyQualifiedName,
+    HasStructSpec
 {
   /**
    * Create a builder from an jsii spec

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './builder';
 export * from './projen';
-export * from './renderer/typescript';
+export * from './renderer';

--- a/src/projen/projen-struct.ts
+++ b/src/projen/projen-struct.ts
@@ -7,6 +7,7 @@ import {
   HasProperties,
   IStructBuilder,
   HasFullyQualifiedName,
+  HasStructSpec,
 } from '../builder';
 
 export interface ProjenStructOptions {
@@ -56,7 +57,11 @@ export interface ProjenStructOptions {
  */
 export class ProjenStruct
   extends Component
-  implements IStructBuilder, HasProperties, HasFullyQualifiedName
+  implements
+    IStructBuilder,
+    HasProperties,
+    HasFullyQualifiedName,
+    HasStructSpec
 {
   private builder: Struct;
 
@@ -90,6 +95,9 @@ export class ProjenStruct
     });
   }
 
+  public get spec() {
+    return this.builder.spec;
+  }
   filter(predicate: (prop: Property) => boolean): IStructBuilder {
     this.builder.filter(predicate);
     return this;

--- a/src/projen/ts-interface.ts
+++ b/src/projen/ts-interface.ts
@@ -23,6 +23,6 @@ export class TypeScriptInterfaceFile extends TextFile {
 
     const renderer = new TypeScriptRenderer(options);
     this.addLine(`// ${this.marker}`);
-    this.addLine(renderer.renderStruct(spec));
+    this.addLine(renderer.renderStructSpec(spec));
   }
 }

--- a/src/renderer/typescript.ts
+++ b/src/renderer/typescript.ts
@@ -9,6 +9,7 @@ import {
   Property,
   TypeReference,
 } from '@jsii/spec';
+import { HasStructSpec } from '../builder';
 import { compareLowerCase, comparePath } from '../private';
 
 /**
@@ -48,7 +49,17 @@ export class TypeScriptRenderer {
     this.buffer = new CodeBuffer(' '.repeat(options.indent ?? 2));
   }
 
-  public renderStruct(spec: InterfaceType): string {
+  /**
+   * Render something that has a struct spec
+   */
+  public renderStruct(struct: HasStructSpec): string {
+    return this.renderStructSpec(struct.spec);
+  }
+
+  /**
+   * Render a jsii InterfaceType spec
+   */
+  public renderStructSpec(spec: InterfaceType): string {
     this.buffer.flush();
 
     this.renderImports(extractImports(spec, this.options.importLocations));

--- a/test/builder/__snapshots__/struct.test.ts.snap
+++ b/test/builder/__snapshots__/struct.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can render a struct directly 1`] = `
+"
+export interface MyFunctionProps {
+  /**
+   * A directory tree that may contain *.ts files that can be referenced from your projenrc typescript file.
+   * @default "projenrc"
+   * @stability experimental
+   */
+  readonly projenCodeDir?: string;
+  /**
+   * The name of the projenrc file.
+   * @default ".projenrc.ts"
+   * @stability experimental
+   */
+  readonly filename?: string;
+}
+"
+`;

--- a/test/builder/struct.test.ts
+++ b/test/builder/struct.test.ts
@@ -1,0 +1,18 @@
+import { Struct, TypeScriptRenderer } from '../../src';
+
+test('can render a struct directly', () => {
+  // ARRANGE
+  const renderer = new TypeScriptRenderer();
+
+  // ACT
+  const struct = Struct.empty('@my-scope/my-pkg.MyFunctionProps');
+  struct.mixin(Struct.fromFqn('projen.typescript.ProjenrcOptions'));
+
+  // PREPARE
+  const renderedFile = renderer.renderStruct(struct);
+
+  // ASSERT
+  expect(renderedFile).toMatchSnapshot();
+  expect(renderedFile).toContain('projenCodeDir');
+  expect(renderedFile).toContain('filename');
+});


### PR DESCRIPTION
BREAKING CHANGE: Renamed `TypeScriptRenderer.renderStruct()` to `TypeScriptRenderer.renderStructSpec()`