### PR TITLE
fix: `@default` tag is rendered for required properties

### DIFF
--- a/test/projen/__snapshots__/projen-struct.test.ts.snap
+++ b/test/projen/__snapshots__/projen-struct.test.ts.snap
@@ -55,7 +55,6 @@ exports[`can update props 1`] = `
 export interface MyInterface {
   /**
    * New summary
-   * @default "projenrc"
    * @stability stable
    * @pjnew "newVal"
    */

--- a/test/projen/__snapshots__/ts-interface.test.ts.snap
+++ b/test/projen/__snapshots__/ts-interface.test.ts.snap
@@ -10,7 +10,6 @@ import { github, GitOptions, IgnoreFileOptions, javascript, LoggerOptions, Proje
 export interface TypeScriptProjectOptions {
   /**
    * This is the name of your project.
-   * @default $BASEDIR
    * @stability experimental
    * @featured true
    */
@@ -604,7 +603,6 @@ export interface TypeScriptProjectOptions {
   readonly workflowRunsOn?: Array<string>;
   /**
    * The name of the main release branch.
-   * @default "main"
    * @stability experimental
    */
   readonly defaultReleaseBranch: string;

--- a/test/projen/projen-struct.test.ts
+++ b/test/projen/projen-struct.test.ts
@@ -7,6 +7,16 @@ import {
 import { synthSnapshot } from 'projen/lib/util/synth';
 import { Struct, ProjenStruct } from '../../src';
 
+class TestProject extends TypeScriptProject {
+  public constructor(options: Partial<TypeScriptProjectOptions> = {}) {
+    super({
+      name: 'test',
+      defaultReleaseBranch: 'main',
+      ...options,
+    });
+  }
+}
+
 test('can mixin a struct', () => {
   // ARRANGE
   const project = new TestProject();
@@ -168,7 +178,6 @@ test('can update props', () => {
   // ASSERT
   expect(renderedFile).toContain('New summary');
   expect(renderedFile).toContain('@stability stable');
-  expect(renderedFile).toContain('@default "projenrc"');
   expect(renderedFile).toContain('@pjnew "newVal"');
   expect(renderedFile).toMatchSnapshot();
 });
@@ -434,16 +443,6 @@ test('can use struct as type in update', () => {
     'readonly projenrcTsOptions?: MyInterface'
   );
 });
-
-class TestProject extends TypeScriptProject {
-  public constructor(options: Partial<TypeScriptProjectOptions> = {}) {
-    super({
-      name: 'test',
-      defaultReleaseBranch: 'main',
-      ...options,
-    });
-  }
-}
 
 test('can create a struct from empty', () => {
   // ARRANGE

--- a/test/renderer/__snapshots__/typescript.test.ts.snap
+++ b/test/renderer/__snapshots__/typescript.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`required properties do not render a default 1`] = `
+"
+export interface MyFunctionProps {
+  readonly requiredProp: string;
+}
+"
+`;

--- a/test/renderer/__snapshots__/typescript.test.ts.snap
+++ b/test/renderer/__snapshots__/typescript.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`required properties can be forced to render a default 1`] = `
+"
+export interface MyFunctionProps {
+  /**
+   * @default "foobar"
+   */
+  readonly requiredProp: string;
+}
+"
+`;
+
 exports[`required properties do not render a default 1`] = `
 "
 export interface MyFunctionProps {

--- a/test/renderer/typescript.test.ts
+++ b/test/renderer/typescript.test.ts
@@ -22,3 +22,26 @@ test('required properties do not render a default', () => {
   expect(renderedFile).not.toContain('@default');
   expect(renderedFile).not.toContain('foobar');
 });
+
+test('required properties can be forced to render a default', () => {
+  // ARRANGE
+  const renderer = new TypeScriptRenderer({
+    defaultTagsForRequiredProps: true,
+  });
+  const struct = Struct.empty('@my-scope/my-pkg.MyFunctionProps');
+  struct.add({
+    name: 'requiredProp',
+    type: { primitive: PrimitiveType.String },
+    optional: false,
+    docs: {
+      default: '"foobar"',
+    },
+  });
+
+  // ACT
+  const renderedFile = renderer.renderStruct(struct);
+
+  // ASSERT
+  expect(renderedFile).toMatchSnapshot();
+  expect(renderedFile).toContain('@default "foobar"');
+});

--- a/test/renderer/typescript.test.ts
+++ b/test/renderer/typescript.test.ts
@@ -1,0 +1,24 @@
+import { PrimitiveType } from '@jsii/spec';
+import { Struct, TypeScriptRenderer } from '../../src';
+
+test('required properties do not render a default', () => {
+  // ARRANGE
+  const renderer = new TypeScriptRenderer();
+  const struct = Struct.empty('@my-scope/my-pkg.MyFunctionProps');
+  struct.add({
+    name: 'requiredProp',
+    type: { primitive: PrimitiveType.String },
+    optional: false,
+    docs: {
+      default: '"foobar"',
+    },
+  });
+
+  // ACT
+  const renderedFile = renderer.renderStruct(struct);
+
+  // ASSERT
+  expect(renderedFile).toMatchSnapshot();
+  expect(renderedFile).not.toContain('@default');
+  expect(renderedFile).not.toContain('foobar');
+});


### PR DESCRIPTION
In TS land this does still show up in IntelliSense and will confuse users

Fixes #62 