### PR TITLE
feat: add partial utility type builder

### DIFF
--- a/src/builder/struct.ts
+++ b/src/builder/struct.ts
@@ -151,6 +151,14 @@ export class Struct
     return this.filter((prop) => null == prop.docs?.deprecated);
   }
 
+  public allOptional() {
+    this._properties.forEach((property) => {
+      property.optional = true;
+    });
+
+    return this;
+  }
+
   public add(...props: Property[]) {
     for (const prop of props.reverse()) {
       this._properties.set(prop.name, prop);

--- a/src/projen/projen-struct.ts
+++ b/src/projen/projen-struct.ts
@@ -106,6 +106,10 @@ export class ProjenStruct
     this.builder.withoutDeprecated();
     return this;
   }
+  allOptional(): IStructBuilder {
+    this.builder.allOptional();
+    return this;
+  }
   add(...props: Property[]): IStructBuilder {
     this.builder.add(...props);
     return this;

--- a/test/projen/projen-struct.test.ts
+++ b/test/projen/projen-struct.test.ts
@@ -119,6 +119,34 @@ test('can ignore deprecated props', () => {
   expect(renderedFile).toContain('currentProp');
 });
 
+test('can make all props optional', () => {
+  // ARRANGE
+  const project = new TestProject();
+
+  // ACT
+  const struct = new ProjenStruct(project, { name: 'MyInterface' });
+  struct.add(
+    {
+      name: 'optionalProp',
+      type: { primitive: PrimitiveType.Boolean },
+      optional: true,
+    },
+    {
+      name: 'requiredProp',
+      type: { primitive: PrimitiveType.Boolean },
+      optional: false,
+    }
+  );
+  struct.allOptional();
+
+  // PREPARE
+  const renderedFile = synthSnapshot(project)['src/MyInterface.ts'];
+
+  // ASSERT
+  expect(renderedFile).toContain('optionalProp?: boolean');
+  expect(renderedFile).toContain('requiredProp?: boolean');
+});
+
 test('can overwrite props', () => {
   // ARRANGE
   const project = new TestProject();


### PR DESCRIPTION
Adding a builder to simulate the Partial Typescript utility type.

This helps cut down on maintenance of the struct declaration long-term since it removes the need to hardcode any mixed-in property names.

Closes #61