### PR TITLE
fix: add alloptional to istructinterface

### DIFF
--- a/src/builder/struct.ts
+++ b/src/builder/struct.ts
@@ -49,6 +49,11 @@ export interface IStructBuilder {
   omit(...remove: string[]): IStructBuilder;
 
   /**
+   * Mark all properties as optional.
+   */
+  allOptional(): IStructBuilder;
+
+  /**
    * Remove all deprecated properties.
    */
   withoutDeprecated(): IStructBuilder;


### PR DESCRIPTION
Missed adding the allOptional method to the IStructBuilder interface, which breaks the TS experience.