### PR TITLE
fix!: @default not rendered on required properties

### DIFF
--- a/src/renderer/typescript.ts
+++ b/src/renderer/typescript.ts
@@ -42,7 +42,10 @@ export interface TypeScriptRendererOptions {
   /**
    * Render `@default` doctag also for required (not optional) properties.
    *
-   * @default false
+   * The tag is needed for `projen new` to fill in required properties at project creation time.
+   *
+   * @default true
+   * @deprecated This should not be a concern for the renderer, instead remove the doctag from required properties before rendering.
    */
   readonly defaultTagsForRequiredProps?: boolean;
 
@@ -66,7 +69,7 @@ export class TypeScriptRenderer {
     this.options = {
       importLocations: options.importLocations ?? {},
       indent: options.indent ?? 2,
-      defaultTagsForRequiredProps: options.defaultTagsForRequiredProps ?? false,
+      defaultTagsForRequiredProps: options.defaultTagsForRequiredProps ?? true,
       useTypeImports: options.useTypeImports ?? false,
     };
     this.buffer = new CodeBuffer(' '.repeat(this.options.indent));

--- a/test/projen/__snapshots__/projen-struct.test.ts.snap
+++ b/test/projen/__snapshots__/projen-struct.test.ts.snap
@@ -73,6 +73,7 @@ export interface MyInterface {
   readonly swc?: boolean;
   /**
    * New summary
+   * @default "projenrc"
    * @stability stable
    * @pjnew "newVal"
    */

--- a/test/projen/__snapshots__/ts-interface.test.ts.snap
+++ b/test/projen/__snapshots__/ts-interface.test.ts.snap
@@ -10,6 +10,7 @@ import { github, GitOptions, IgnoreFileOptions, javascript, LoggerOptions, Proje
 export interface TypeScriptProjectOptions {
   /**
    * This is the name of your project.
+   * @default $BASEDIR
    * @stability experimental
    * @featured true
    */
@@ -609,6 +610,7 @@ export interface TypeScriptProjectOptions {
   readonly workflowRunsOn?: Array<string>;
   /**
    * The name of the main release branch.
+   * @default "main"
    * @stability experimental
    */
   readonly defaultReleaseBranch: string;

--- a/test/renderer/__snapshots__/typescript.test.ts.snap
+++ b/test/renderer/__snapshots__/typescript.test.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`required properties can be forced to not render a default 1`] = `
+"
+export interface MyFunctionProps {
+  readonly requiredProp: string;
+}
+"
+`;
+
 exports[`required properties can be forced to render a default 1`] = `
 "
 export interface MyFunctionProps {
@@ -11,9 +19,12 @@ export interface MyFunctionProps {
 "
 `;
 
-exports[`required properties do not render a default 1`] = `
+exports[`required properties do render @default by default 1`] = `
 "
 export interface MyFunctionProps {
+  /**
+   * @default "foobar"
+   */
   readonly requiredProp: string;
 }
 "

--- a/test/renderer/typescript.test.ts
+++ b/test/renderer/typescript.test.ts
@@ -1,7 +1,7 @@
 import { PrimitiveType } from '@jsii/spec';
 import { Struct, TypeScriptRenderer } from '../../src';
 
-test('required properties do not render a default', () => {
+test('required properties do render @default by default', () => {
   // ARRANGE
   const renderer = new TypeScriptRenderer();
   const struct = Struct.empty('@my-scope/my-pkg.MyFunctionProps');
@@ -19,8 +19,8 @@ test('required properties do not render a default', () => {
 
   // ASSERT
   expect(renderedFile).toMatchSnapshot();
-  expect(renderedFile).not.toContain('@default');
-  expect(renderedFile).not.toContain('foobar');
+  expect(renderedFile).toContain('@default');
+  expect(renderedFile).toContain('foobar');
 });
 
 test('required properties can be forced to render a default', () => {
@@ -44,4 +44,28 @@ test('required properties can be forced to render a default', () => {
   // ASSERT
   expect(renderedFile).toMatchSnapshot();
   expect(renderedFile).toContain('@default "foobar"');
+});
+
+test('required properties can be forced to not render a default', () => {
+  // ARRANGE
+  const renderer = new TypeScriptRenderer({
+    defaultTagsForRequiredProps: false,
+  });
+  const struct = Struct.empty('@my-scope/my-pkg.MyFunctionProps');
+  struct.add({
+    name: 'requiredProp',
+    type: { primitive: PrimitiveType.String },
+    optional: false,
+    docs: {
+      default: '"foobar"',
+    },
+  });
+
+  // ACT
+  const renderedFile = renderer.renderStruct(struct);
+
+  // ASSERT
+  expect(renderedFile).toMatchSnapshot();
+  expect(renderedFile).not.toContain('@default');
+  expect(renderedFile).not.toContain('foobar');
 });


### PR DESCRIPTION
BREAKING CHANGE: The @default doctag is now rendered by default for required properties. Use `outputFileOptions.defaultTagsForRequiredProps` to restore the previous behavior.

The @default tag is used by `projen new` to populate required options that are not provided via the cli. In hindsight this should not have been a responsibility for the renderer. The option is now deprecated and will be removed once an easy way to remove the tag for all required properties has been added.

Fixes #142 